### PR TITLE
Fix job title field missplacement

### DIFF
--- a/.~lock.my_job_applications (copy).csv#
+++ b/.~lock.my_job_applications (copy).csv#
@@ -1,0 +1,1 @@
+,alex,alex-Latitude-E5450,19.02.2023 17:08,file:///home/alex/.config/libreoffice/4;

--- a/exporters/csv_exporter.py
+++ b/exporters/csv_exporter.py
@@ -15,6 +15,7 @@ class CSVExporter:
     Singleton that exports JobApplications to csv files
     """
     filename = "my_job_applications.csv"
+    delimiter = "@"
     existing_urls = CSVLoader.load_job_urls(filename)  # job urls already in the archive
 
     @staticmethod
@@ -34,7 +35,8 @@ class CSVExporter:
                 return 1
             fieldnames = list(job_applications[0].to_dict().keys())
             writer = csv.DictWriter(csvfile,
-                                    fieldnames=fieldnames)
+                                    fieldnames=fieldnames,
+                                    delimiter=CSVExporter.delimiter)
             if not file_exists:
                 writer.writeheader()
             for job_application in job_applications:
@@ -42,7 +44,18 @@ class CSVExporter:
                 if already_in_csv:
                     logger.warning("Existing job url found! Stopping export.")
                     return 1
-                writer.writerow(job_application.to_dict())
+                row = {
+                    key: CSVExporter.remove_delimiter(value)
+                    for key, value in job_application.to_dict().items()
+                    }
+                writer.writerow(row)
             logger.info("Exported %s jobs", len(job_applications))
         return 0
+
+    @staticmethod
+    def remove_delimiter(job_application_field: str) -> str:
+        """
+        Remove occurances of delimiter because it breaks the data.
+        """
+        return job_application_field.replace(CSVExporter.delimiter, '')
     

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ def main():
         headless=True
     )
 
-    linkedin_parser.start(until_page=10)
+    linkedin_parser.run()
 
 
 if __name__ == "__main__":

--- a/models/job_application.py
+++ b/models/job_application.py
@@ -1,6 +1,7 @@
 """
 Structures to describe job application data.
 """
+import re
 
 class JobApplication:
     """
@@ -41,8 +42,8 @@ class JobApplication:
         Same with the linkedin status.
         """
         all_valid = self._is_valid_url() and \
-            self._is_valid_company_name() and \
-            self._is_valid_linkedin_status()
+            (self._is_valid_company_name() or \
+             self._is_valid_linkedin_status())
         return all_valid
 
     def _is_valid_url(self) -> bool:
@@ -53,7 +54,8 @@ class JobApplication:
         return is_empty
 
     def _is_valid_linkedin_status(self) -> bool:
-        is_empty = bool(self.linkedin_status)
+        status_pattern = re.compile(r".+ \d+\w+ ago")
+        is_empty = bool(status_pattern.search(self.linkedin_status))
         return is_empty
 
     def __hash__(self) -> int:

--- a/parsers/linkedin_parser.py
+++ b/parsers/linkedin_parser.py
@@ -72,7 +72,7 @@ class LinkedInParser:
         self.driver.implicitly_wait(1)
         logger.info("Login successful!")
 
-    def start(self, from_page=0, until_page=None) -> None:
+    def run(self, from_page=0, until_page=None) -> None:
         """
         Iterate through LinkedIn pages of applied jobs.
         Scrap job application information such as url, company name, etc.
@@ -204,11 +204,10 @@ class LinkedInParser:
         """
         _html_box_containing_job_url = {"a": "app-aware-link "}
         job_title_found = div_box.find_all(_html_box_containing_job_url)
+        res = ""
         for elem in job_title_found:
             res = self._extract_text_from_div(str(elem))
-            if res:
-                return res
-        return ""
+        return res
 
     def _extract_text_from_div(self, div: str) -> str:
         """


### PR DESCRIPTION
- The delimiter should have been removed
from job application field before being written to the csv.
- Use a weirder delimiter `@` for robustness.
-  Improve `_is_valid_linkedin_status`

Each job application field should not contain
the same character (',') that is used as a
delimiter in the exporters and loaders because
bugs occur. (e.g. misplacement of values from the correct columns in the spreadsheet).

*The empty job title problem still persists, however the code must now be more robust.*